### PR TITLE
feat(IE): don't test on IE8

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ export default {
     platform: 'Windows 10'
   }, {
     name: 'internet explorer',
-    version: '8..11'
+    version: '9..11'
   }, {
     name: 'safari',
     version: '-3..latest'


### PR DESCRIPTION
the JavaScript Client -- for now -- will only be transpiled down to IE9, because IE8 really doesn't make any sense anymore. Before this change builds like [this](https://travis-ci.org/algolia/algoliasearch-client-javascript/builds/248362872) fail in IE8.